### PR TITLE
Fix Quill suggestion module initialization

### DIFF
--- a/src/components/editor/SuggestionFormatModule.ts
+++ b/src/components/editor/SuggestionFormatModule.ts
@@ -85,7 +85,17 @@ export const SuggestionFormatModule = {
       // Register formats with Quill
       Quill.register(SuggestionAddFormat);
       Quill.register(SuggestionRemoveFormat);
-      
+
+      // Register a no-op module so Quill doesn't error when loading
+      class SuggestionFormat {
+        quill: any;
+        constructor(quill: any) {
+          this.quill = quill;
+        }
+      }
+
+      Quill.register('modules/suggestionFormat', SuggestionFormat);
+
       // Mark as registered to avoid double registration
       Quill._suggestionFormatModuleRegistered = true;
       


### PR DESCRIPTION
## Summary
- register `modules/suggestionFormat` in SuggestionFormatModule

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685c1e47aa18832d96ed41c66b30b779